### PR TITLE
rm protocol from endpoint config

### DIFF
--- a/lib/dalli/elasticache.rb
+++ b/lib/dalli/elasticache.rb
@@ -7,7 +7,7 @@ module Dalli
     attr_accessor :config_host, :config_port, :options
 
     def initialize(config_endpoint, options={})
-      @config_host, @config_port = config_endpoint.split(':')
+      @config_host, @config_port = config_endpoint.gsub(/http.*:\/\//,'').split(':')
       @config_port ||= 11211
       @options = options
 


### PR DESCRIPTION
http://rubular.com/r/14VD2cECDf

as a first time user, i was trying to connect to elasticache and thought perhaps i needed https. doing so parsed using split and produced an invalid endpoint string.
