### PR TITLE
Change how hosts are resolved

### DIFF
--- a/lib/dalli/elasticache.rb
+++ b/lib/dalli/elasticache.rb
@@ -27,7 +27,7 @@ module Dalli
 
     def config_get_cluster
       s = TCPSocket.new(config_host, config_port)
-      s.puts "config get cluster\r\n"
+      s.puts "get AmazonElastiCache:cluster\r\n"
       data = []
       while (line = s.gets) != "END\r\n"
         data << line


### PR DESCRIPTION
Changes the auto discovery mechanism to look for the AWS-specific cache key that contains the hosts. This process of host name resolution is backwards compatible with Memcached version less than 1.4.14. See this link for more information:
http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.AddingToYourClientLibrary.html
