### PR TITLE
Fix NameError in refresh method

### DIFF
--- a/lib/dalli/elasticache.rb
+++ b/lib/dalli/elasticache.rb
@@ -38,6 +38,7 @@ module Dalli
     
     # Clear all cached data from the cluster endpoint
     def refresh
+      config_endpoint = "#{endpoint.host}:#{endpoint.port}"
       @endpoint = Dalli::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint)
       
       self


### PR DESCRIPTION
`config_endpoint` was undefined in refresh method.
