### PR TITLE
Raise exception if endpoint is wrong format

### DIFF
--- a/lib/dalli/elasticache/auto_discovery/endpoint.rb
+++ b/lib/dalli/elasticache/auto_discovery/endpoint.rb
@@ -19,7 +19,7 @@ module Dalli
           ENDPOINT_REGEX.match(endpoint) do |m|
             @host = m[1]
             @port = m[2].to_i
-          end
+          end or raise ArgumentError.new("unable to parse hostname and port from endpoint: #{endpoint}")
         end
     
         # A cached ElastiCache::StatsResponse

--- a/lib/dalli/elasticache/auto_discovery/endpoint.rb
+++ b/lib/dalli/elasticache/auto_discovery/endpoint.rb
@@ -2,52 +2,54 @@ module Dalli
   module Elasticache
     module AutoDiscovery
       class Endpoint
-        
+
         # Endpoint configuration
         attr_reader :host
         attr_reader :port
-    
+
         # Matches Strings like "my-host.cache.aws.com:11211"
         ENDPOINT_REGEX = /([-.a-zA-Z0-9]+):(\d+)/
-    
+
         STATS_COMMAND  = "stats\r\n"
         CONFIG_COMMAND = "config get cluster\r\n"
         # Legacy command for version < 1.4.14
         OLD_CONFIG_COMMAND = "get AmazonElastiCache:cluster\r\n"
-    
+
         def initialize(endpoint)
-          ENDPOINT_REGEX.match(endpoint) do |m|
-            @host = m[1]
-            @port = m[2].to_i
-          end or raise ArgumentError.new("unable to parse hostname and port from endpoint: #{endpoint}")
+          if match = ENDPOINT_REGEX.match(endpoint)
+            @host = match[1]
+            @port = match[2].to_i
+          else
+            raise ArgumentError.new("unable to parse hostname and port from endpoint: #{endpoint}")
+          end
         end
-    
+
         # A cached ElastiCache::StatsResponse
         def stats
           @stats ||= get_stats_from_remote
         end
-    
+
         # A cached ElastiCache::ConfigResponse
         def config
           @config ||= get_config_from_remote
         end
-    
+
         # The memcached engine version
         def engine_version
           stats.version
         end
-    
+
         protected
-    
+
         def with_socket(&block)
           TCPSocket.new(config_host, config_port)
         end
-    
+
         def get_stats_from_remote
           data = remote_command(STATS_COMMAND)
           StatsResponse.new(data)
         end
-    
+
         def get_config_from_remote
           if engine_version < Gem::Version.new("1.4.14")
             data = remote_command(OLD_CONFIG_COMMAND)
@@ -56,19 +58,19 @@ module Dalli
           end
           ConfigResponse.new(data)
         end
-      
+
         # Send an ASCII command to the endpoint
         #
         # Returns the raw response as a String
         def remote_command(command)
           socket = TCPSocket.new(@host, @port)
           socket.puts command
-        
+
           data = ""
           until (line = socket.readline) =~ /END/
             data << line
           end
-        
+
           socket.close
           data
         end

--- a/spec/endpoint_spec.rb
+++ b/spec/endpoint_spec.rb
@@ -1,16 +1,25 @@
 require_relative 'spec_helper'
 
 describe 'Dalli::Elasticache::AutoDiscovery::Endpoint' do
-  let(:endpoint) do
-    Dalli::Elasticache::AutoDiscovery::Endpoint.new("my-cluster.cfg.use1.cache.amazonaws.com:11211")
-  end
-  
+  subject { Dalli::Elasticache::AutoDiscovery::Endpoint.new(endpoint) }
+
   describe '.new' do
-    it 'parses host' do
-      endpoint.host.should == "my-cluster.cfg.use1.cache.amazonaws.com"
+    context 'endpoint specifies port' do
+      let(:endpoint) { "my-cluster.cfg.use1.cache.amazonaws.com:11211" }
+
+      it 'parses host' do
+        subject.host.should == "my-cluster.cfg.use1.cache.amazonaws.com"
+      end
+      it 'parses port' do
+        subject.port.should == 11211
+      end
     end
-    it 'parses port' do
-      endpoint.port.should == 11211
+    context 'endpoint is plain url (no port)' do
+      let(:endpoint) { "my-cluster.cfg.use1.cache.amazonaws.com" }
+
+      it 'raises ArgumentError' do
+        -> { subject }.should raise_error(ArgumentError)
+      end
     end
   end
 end


### PR DESCRIPTION
So @cpapazian and I were bitten by forgetting to include the colon and port, and when this happens the resulting error (a failure in `remote_command()`) takes a while to track down. 

We initially wrote this as just defaulting the port to 11211 if unspecified. However, this severely increases the pain of debugging connections to non-standard ports with only a very minor usability improvement for everyone else.
