### PR TITLE
Simplify configuration with an actual cache store

### DIFF
--- a/lib/active_support/cache/dalli_elasticache_store.rb
+++ b/lib/active_support/cache/dalli_elasticache_store.rb
@@ -1,0 +1,15 @@
+require 'dalli-elasticache'
+require 'active_support/cache/dalli_store'
+
+module ActiveSupport
+  module Cache
+    class DalliElasticacheStore < DalliStore
+      def initialize(*endpoint_and_options)
+        endpoint, *options = endpoint_and_options
+        elasticache = Dalli::ElastiCache.new(endpoint)
+        super(elasticache.servers, options)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This allows one to do

    config.cache_store = :dalli_elasticache_store, 'someendpoint.cfg.euw1.cache.amazonaws.com:11211', {:failover => true}

as suggested in #12 
