### PR TITLE
:dalli_store will be removed in Dalli 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Configure your environment-specific application settings:
 endpoint    = "my-cluster-name.abc123.cfg.use1.cache.amazonaws.com:11211"
 elasticache = Dalli::ElastiCache.new(endpoint)
 
-config.cache_store = :dalli_store, elasticache.servers, {:expires_in => 1.day, :compress => true}
+config.cache_store = :mem_cache_store, elasticache.servers, {:expires_in => 1.day, :compress => true}
 ```
 
 Note that the ElastiCache server list will be refreshed each time an app server process starts.


### PR DESCRIPTION
I got this error when deploying code to production.

![image](https://user-images.githubusercontent.com/1224077/148177774-82d1dc02-50c9-44cc-8e29-f6d9e587e94d.png)

Then, I checked the release changes from dalli, and found  dalli_store will be removed in Dalli 3.0. 

They recommend using Rails' official :mem_cache_store instead. 

https://guides.rubyonrails.org/caching_with_rails.html

## Reference

https://github.com/petergoldstein/dalli/blob/main/History.md#2711