### PR TITLE
Add Rubocop and get Rubocop passing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint - Ruby 2.6
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 2.6
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+        bundler-cache: true # 'bundle install' and cache
+    - name: Run Rubocop
+      run: bundle exec rubocop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,11 +5,12 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: [2.5, 2.6, 2.7, '3.0', jruby-9.2, jruby-9.3]
+        ruby-version: [2.6, 2.7, '3.0', 3.1, jruby-9.3, ruby-head, jruby-head]
 
+    name: Specs - Ruby ${{ matrix.ruby-version }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.ruby-version
 coverage
 InstalledFiles
 lib/bundler/man

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,30 @@
+require:
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-rspec
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 2.6
+
+Metrics/BlockLength:
+  Max: 50
+  Exclude:
+    - 'spec/**/*'
+
+Naming/FileName:
+  Exclude:
+    - 'lib/dalli-elasticache.rb'
+
+Style/Documentation:
+  Exclude:
+    - 'spec/**/*'
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,10 @@
-require "rubygems"
-require "bundler/setup"
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'bundler/setup'
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:test)
 
-task :default => :test
+task default: :test

--- a/dalli-elasticache.gemspec
+++ b/dalli-elasticache.gemspec
@@ -1,34 +1,37 @@
-# -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib/', __FILE__)
-$:.unshift lib unless $:.include?(lib)
+# frozen_string_literal: true
 
-require 'dalli/elasticache/version'
+require_relative './lib/dalli/elasticache/version'
 
 Gem::Specification.new do |s|
   s.name     = 'dalli-elasticache'
   s.version  = Dalli::ElastiCache::VERSION
   s.licenses = ['MIT']
-  
+
   s.summary     = "Configure Dalli clients with ElastiCache's AutoDiscovery"
-  s.description = <<-EOS
+  s.description = <<-DESC
     This gem provides an interface for fetching cluster information from an AWS
     ElastiCache AutoDiscovery server and configuring a Dalli client to connect
     to all nodes in the cache cluster.
-  EOS
-  
-  s.authors     = ["Aaron Suggs", "Zach Millman"]
-  s.email       = ["aaron@ktheory.com", "zach@magoosh.com"]
+  DESC
+
+  s.authors     = ['Aaron Suggs', 'Zach Millman', 'Peter M. Goldstein']
+  s.email       = ['aaron@ktheory.com', 'zach@magoosh.com', 'peter.m.goldstein@gmail.com']
   s.homepage    = 'http://github.com/ktheory/dalli-elasticache'
-  
-  s.files         = Dir.glob("{bin,lib}/**/*") + %w(README.md Rakefile)
-  s.rdoc_options  = ["--charset=UTF-8"]
-  s.require_paths = ["lib"]
-  s.test_files    = Dir.glob("{test,spec}/**/*")
-  
-  s.required_ruby_version     = '>= 1.9.2' # Maybe less?
+
+  s.files         = Dir.glob('{bin,lib}/**/*') + %w[README.md Rakefile]
+  s.rdoc_options  = ['--charset=UTF-8']
+  s.require_paths = ['lib']
+  s.test_files    = Dir.glob('{test,spec}/**/*')
+
+  s.required_ruby_version     = '>= 2.6.0'
   s.required_rubygems_version = '>= 1.3.5'
-  
+
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
-  s.add_dependency 'dalli', ">= 1.0.0" # ??
+  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop-performance'
+  s.add_development_dependency 'rubocop-rake'
+  s.add_development_dependency 'rubocop-rspec'
+  s.add_dependency 'dalli', '>= 2.0.0'
+  s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/dalli-elasticache.rb
+++ b/lib/dalli-elasticache.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # Support default bundler require path
 require 'dalli/elasticache'

--- a/lib/dalli/elasticache.rb
+++ b/lib/dalli/elasticache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'dalli'
 require 'socket'
 require 'dalli/elasticache/version'
@@ -6,42 +8,60 @@ require 'dalli/elasticache/auto_discovery/config_response'
 require 'dalli/elasticache/auto_discovery/stats_response'
 
 module Dalli
+  ##
+  # Dalli::Elasticache provides an interface for providing a configuration
+  # endpoint for a memcached cluster on ElasticCache and retrieving the
+  # list of addresses (IP and port) for the individual nodes of that cluster.
+  #
+  # This allows the caller to pass that server list to Dalli, which then
+  # distributes cached items consistently over the nodes.
+  ##
   class ElastiCache
     attr_reader :endpoint, :options
-    
-    def initialize(config_endpoint, options={})
+
+    ##
+    # Creates a new Dalli::ElasticCache instance.
+    #
+    # config_endpoint - a String containing the host and (optionally) port of the
+    # configuration endpoint for the cluster.  If not specified the port will
+    # default to 11211.  The host must be either a DNS name or an IPv4 address.  IPv6
+    # addresses are not handled at this time.
+    # dalli_options - a set of options passed to the Dalli::Client that is returned
+    # by the client method.  Otherwise unused.
+    ##
+    def initialize(config_endpoint, dalli_options = {})
       @endpoint = Dalli::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint)
-      @options = options
+      @options = dalli_options
     end
-    
+
     # Dalli::Client configured to connect to the cluster's nodes
     def client
       Dalli::Client.new(servers, options)
     end
-    
+
     # The number of times the cluster configuration has been changed
     #
     # Returns an integer
     def version
       endpoint.config.version
     end
-    
+
     # The cache engine version of the cluster
     def engine_version
       endpoint.engine_version
     end
-    
+
     # List of cluster server nodes with ip addresses and ports
     # Always use host name instead of private elasticache IPs as internal IPs can change after a node is rebooted
     def servers
-      endpoint.config.nodes.map{ |h| "#{h[:host]}:#{h[:port]}" }
+      endpoint.config.nodes.map { |h| "#{h[:host]}:#{h[:port]}" }
     end
-    
+
     # Clear all cached data from the cluster endpoint
     def refresh
       config_endpoint = "#{endpoint.host}:#{endpoint.port}"
       @endpoint = Dalli::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint)
-      
+
       self
     end
   end

--- a/lib/dalli/elasticache/auto_discovery/config_response.rb
+++ b/lib/dalli/elasticache/auto_discovery/config_response.rb
@@ -1,48 +1,46 @@
+# frozen_string_literal: true
+
 module Dalli
   module Elasticache
     module AutoDiscovery
-      
       # This class wraps the raw ASCII response from an Auto Discovery endpoint
       # and provides methods for extracting data from that response.
       #
       # http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.AddingToYourClientLibrary.html
-      
       class ConfigResponse
-        
         # The raw response text
         attr_reader :text
-    
+
         # Matches the version line of the response
-        VERSION_REGEX = /^(\d+)$/
-    
+        VERSION_REGEX = /^(\d+)$/.freeze
+
         # Matches strings like "my-cluster.001.cache.aws.com|10.154.182.29|11211"
-        NODE_REGEX = /(([-.a-zA-Z0-9]+)\|(\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b)\|(\d+))/
-        NODE_LIST_REGEX = /^(#{NODE_REGEX}\s*)+$/
-    
+        NODE_REGEX = /(([-.a-zA-Z0-9]+)\|(\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b)\|(\d+))/.freeze
+        NODE_LIST_REGEX = /^(#{NODE_REGEX}\s*)+$/.freeze
+
         def initialize(response_text)
           @text = response_text.to_s
         end
-    
+
         # The number of times the configuration has been changed
         #
         # Returns an integer
         def version
           VERSION_REGEX.match(@text)[1].to_i
         end
-    
+
         # Node hosts, ip addresses, and ports
         #
         # Returns an Array of Hashes with values for :host, :ip and :port
         def nodes
           NODE_LIST_REGEX.match(@text).to_s.scan(NODE_REGEX).map do |match|
             {
-              :host => match[1],
-              :ip   => match[2],
-              :port => match[3].to_i
+              host: match[1],
+              ip: match[2],
+              port: match[3].to_i
             }
           end
         end
-    
       end
     end
   end

--- a/lib/dalli/elasticache/auto_discovery/endpoint.rb
+++ b/lib/dalli/elasticache/auto_discovery/endpoint.rb
@@ -1,74 +1,77 @@
+# frozen_string_literal: true
+
 module Dalli
   module Elasticache
     module AutoDiscovery
+      ##
+      # This is a representation of the configuration endpoint for
+      # a memcached cluster.  It encapsulates information returned from
+      # that endpoint.
+      ##
       class Endpoint
-        
         # Endpoint configuration
         attr_reader :host
         attr_reader :port
-    
+
         # Matches Strings like "my-host.cache.aws.com:11211"
-        ENDPOINT_REGEX = /([-.a-zA-Z0-9]+):(\d+)/
-    
+        ENDPOINT_REGEX = /([-.a-zA-Z0-9]+):(\d+)/.freeze
+
         STATS_COMMAND  = "stats\r\n"
         CONFIG_COMMAND = "config get cluster\r\n"
+
         # Legacy command for version < 1.4.14
         OLD_CONFIG_COMMAND = "get AmazonElastiCache:cluster\r\n"
-    
+
         def initialize(endpoint)
           ENDPOINT_REGEX.match(endpoint) do |m|
             @host = m[1]
             @port = m[2].to_i
           end
         end
-    
+
         # A cached ElastiCache::StatsResponse
         def stats
-          @stats ||= get_stats_from_remote
+          @stats ||= stats_from_remote
         end
-    
+
         # A cached ElastiCache::ConfigResponse
         def config
-          @config ||= get_config_from_remote
+          @config ||= config_from_remote
         end
-    
+
         # The memcached engine version
         def engine_version
           stats.version
         end
-    
+
         protected
-    
-        def with_socket(&block)
-          TCPSocket.new(config_host, config_port)
-        end
-    
-        def get_stats_from_remote
+
+        def stats_from_remote
           data = remote_command(STATS_COMMAND)
           StatsResponse.new(data)
         end
-    
-        def get_config_from_remote
-          if engine_version < Gem::Version.new("1.4.14")
-            data = remote_command(OLD_CONFIG_COMMAND)
-          else
-            data = remote_command(CONFIG_COMMAND)
-          end
+
+        def config_from_remote
+          data = if engine_version < Gem::Version.new('1.4.14')
+                   remote_command(OLD_CONFIG_COMMAND)
+                 else
+                   remote_command(CONFIG_COMMAND)
+                 end
           ConfigResponse.new(data)
         end
-      
+
         # Send an ASCII command to the endpoint
         #
         # Returns the raw response as a String
         def remote_command(command)
           socket = TCPSocket.new(@host, @port)
           socket.puts command
-        
-          data = ""
-          until (line = socket.readline) =~ /END/
+
+          data = +''
+          until (line = socket.readline).include?('END')
             data << line
           end
-        
+
           socket.close
           data
         end

--- a/lib/dalli/elasticache/auto_discovery/stats_response.rb
+++ b/lib/dalli/elasticache/auto_discovery/stats_response.rb
@@ -1,24 +1,23 @@
+# frozen_string_literal: true
+
 module Dalli
   module Elasticache
     module AutoDiscovery
-      
       # This class wraps the raw ASCII response from an Auto Discovery endpoint
       # and provides methods for extracting data from that response.
       #
       # http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.AddingToYourClientLibrary.html
-      
       class StatsResponse
-        
         # The raw response text
         attr_reader :text
-        
+
         # Matches the version line of the response
-        VERSION_REGEX = /^STAT version ([0-9.]+)\s*$/
-        
+        VERSION_REGEX = /^STAT version ([0-9.]+)\s*$/.freeze
+
         def initialize(response_text)
           @text = response_text.to_s
         end
-        
+
         # Extract the engine version stat
         #
         # Returns a Gem::Version

--- a/lib/dalli/elasticache/version.rb
+++ b/lib/dalli/elasticache/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Dalli
   class ElastiCache
-    VERSION = "0.2.0"
+    VERSION = '0.2.0'
   end
 end

--- a/spec/config_response_spec.rb
+++ b/spec/config_response_spec.rb
@@ -1,32 +1,36 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 describe 'Dalli::Elasticache::AutoDiscovery::ConfigResponse' do
   let :response do
-    text = "CONFIG cluster 0 141\r\n12\nmycluster.0001.cache.amazonaws.com|10.112.21.1|11211 mycluster.0002.cache.amazonaws.com|10.112.21.2|11211 mycluster.0003.cache.amazonaws.com|10.112.21.3|11211\n\r\n"
+    text = "CONFIG cluster 0 141\r\n12\nmycluster.0001.cache.amazonaws.com|10.112.21.1|11211 "\
+           'mycluster.0002.cache.amazonaws.com|10.112.21.2|11211 '\
+           "mycluster.0003.cache.amazonaws.com|10.112.21.3|11211\n\r\n"
     Dalli::Elasticache::AutoDiscovery::ConfigResponse.new(text)
   end
-  
+
   describe '#version' do
     it 'parses version' do
-      response.version.should == 12
+      expect(response.version).to eq 12
     end
   end
 
   describe '#nodes' do
     it 'parses hosts' do
-      response.nodes.map{|s| s[:host]}.should == [
-        "mycluster.0001.cache.amazonaws.com",
-        "mycluster.0002.cache.amazonaws.com",
-        "mycluster.0003.cache.amazonaws.com"
+      expect(response.nodes.map { |s| s[:host] }).to eq [
+        'mycluster.0001.cache.amazonaws.com',
+        'mycluster.0002.cache.amazonaws.com',
+        'mycluster.0003.cache.amazonaws.com'
       ]
     end
-  
+
     it 'parses ip addresses' do
-      response.nodes.map{|s| s[:ip]}.should == ["10.112.21.1", "10.112.21.2", "10.112.21.3"]
+      expect(response.nodes.map { |s| s[:ip] }).to eq ['10.112.21.1', '10.112.21.2', '10.112.21.3']
     end
-  
+
     it 'parses ports' do
-      response.nodes.map{|s| s[:port]}.should == [11211, 11211, 11211]
+      expect(response.nodes.map { |s| s[:port] }).to eq [11_211, 11_211, 11_211]
     end
   end
 end

--- a/spec/elasticache_spec.rb
+++ b/spec/elasticache_spec.rb
@@ -1,62 +1,126 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 describe 'Dalli::ElastiCache::Endpoint' do
-  let(:cache) do
-    options = {
-      :expires_in => 24*60*60,
-      :namespace => "my_app",
-      :compress => true
+  let(:dalli_options) do
+    {
+      expires_in: 24 * 60 * 60,
+      namespace: 'my_app',
+      compress: true
     }
-    Dalli::ElastiCache.new("my-cluster.cfg.use1.cache.amazonaws.com:11211", options)
   end
 
-  let(:config_text) { "CONFIG cluster 0 141\r\n12\nmycluster.0001.cache.amazonaws.com|10.112.21.1|11211 mycluster.0002.cache.amazonaws.com|10.112.21.2|11211 mycluster.0003.cache.amazonaws.com|10.112.21.3|11211\n\r\n" }
+  let(:config_endpoint) { 'my-cluster.cfg.use1.cache.amazonaws.com:11211' }
+  let(:cache) do
+    Dalli::ElastiCache.new(config_endpoint, dalli_options)
+  end
+
+  let(:config_text) do
+    "CONFIG cluster 0 141\r\n12\nmycluster.0001.cache.amazonaws.com|10.112.21.1|11211 "\
+      'mycluster.0002.cache.amazonaws.com|10.112.21.2|11211 '\
+      "mycluster.0003.cache.amazonaws.com|10.112.21.3|11211\n\r\n"
+  end
   let(:response) { Dalli::Elasticache::AutoDiscovery::ConfigResponse.new(config_text) }
 
   describe '.new' do
     it 'builds endpoint' do
-      cache.endpoint.host.should == "my-cluster.cfg.use1.cache.amazonaws.com"
-      cache.endpoint.port.should == 11211
+      expect(cache.endpoint.host).to eq 'my-cluster.cfg.use1.cache.amazonaws.com'
+      expect(cache.endpoint.port).to eq 11_211
     end
-    
+
     it 'stores Dalli options' do
-      cache.options[:expires_in].should == 24*60*60
-      cache.options[:namespace].should == "my_app"
-      cache.options[:compress].should == true
+      expect(cache.options[:expires_in]).to eq 24 * 60 * 60
+      expect(cache.options[:namespace]).to eq 'my_app'
+      expect(cache.options[:compress]).to eq true
     end
   end
-  
+
   describe '#client' do
-    it 'builds with node list'
-    it 'builds with options'
+    let(:client) { cache.client }
+    let(:stub_endpoint) { Dalli::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint) }
+    let(:mock_dalli) { instance_double(Dalli::Client) }
+
+    before do
+      allow(Dalli::Elasticache::AutoDiscovery::Endpoint).to receive(:new)
+        .with(config_endpoint).and_return(stub_endpoint)
+      allow(stub_endpoint).to receive(:config_from_remote).and_return(response)
+      allow(Dalli::Client).to receive(:new)
+        .with(['mycluster.0001.cache.amazonaws.com:11211',
+               'mycluster.0002.cache.amazonaws.com:11211',
+               'mycluster.0003.cache.amazonaws.com:11211'],
+              dalli_options).and_return(mock_dalli)
+    end
+
+    it 'builds with node list and dalli options' do
+      expect(client).to eq(mock_dalli)
+      expect(stub_endpoint).to have_received(:config_from_remote)
+      expect(Dalli::Client).to have_received(:new)
+        .with(['mycluster.0001.cache.amazonaws.com:11211',
+               'mycluster.0002.cache.amazonaws.com:11211',
+               'mycluster.0003.cache.amazonaws.com:11211'],
+              dalli_options)
+    end
   end
-  
+
   describe '#servers' do
-    before { Dalli::Elasticache::AutoDiscovery::Endpoint.any_instance.should_receive(:get_config_from_remote).and_return(response) }
+    let(:stub_endpoint) { Dalli::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint) }
+
+    before do
+      allow(Dalli::Elasticache::AutoDiscovery::Endpoint).to receive(:new)
+        .with(config_endpoint).and_return(stub_endpoint)
+      allow(stub_endpoint).to receive(:config_from_remote).and_return(response)
+    end
 
     it 'lists addresses and ports' do
-      cache.servers.should == ["mycluster.0001.cache.amazonaws.com:11211", "mycluster.0002.cache.amazonaws.com:11211", "mycluster.0003.cache.amazonaws.com:11211"]
+      expect(cache.servers).to eq ['mycluster.0001.cache.amazonaws.com:11211',
+                                   'mycluster.0002.cache.amazonaws.com:11211',
+                                   'mycluster.0003.cache.amazonaws.com:11211']
+      expect(stub_endpoint).to have_received(:config_from_remote)
+      expect(Dalli::Elasticache::AutoDiscovery::Endpoint).to have_received(:new).with(config_endpoint)
     end
   end
-  
+
   describe '#version' do
+    let(:mock_config) { instance_double(Dalli::Elasticache::AutoDiscovery::ConfigResponse) }
+    let(:version) { rand(1..20) }
+
+    before do
+      allow(cache.endpoint).to receive(:config).and_return(mock_config)
+      allow(mock_config).to receive(:version).and_return(version)
+    end
+
+    it 'delegates the call to the config on the endpoint' do
+      expect(cache.version).to eq(version)
+      expect(cache.endpoint).to have_received(:config)
+      expect(mock_config).to have_received(:version)
+    end
   end
-  
+
   describe '#engine_version' do
+    let(:engine_version) { [Gem::Version.new('1.6.13'), Gem::Version.new('1.4.14')].sample }
+
+    before do
+      allow(cache.endpoint).to receive(:engine_version).and_return(engine_version)
+    end
+
+    it 'delegates the call to the endpoint' do
+      expect(cache.engine_version).to eq(engine_version)
+      expect(cache.endpoint).to have_received(:engine_version)
+    end
   end
-  
+
   describe '#refresh' do
     it 'clears endpoint configuration' do
       stale_endpoint = cache.endpoint
-      cache.refresh.endpoint.should_not === stale_endpoint
+      expect(cache.refresh.endpoint).not_to eq stale_endpoint
     end
-    
+
     it 'builds endpoint with same configuration' do
       stale_endpoint = cache.endpoint
       cache.refresh
-      cache.endpoint.host.should == stale_endpoint.host
-      cache.endpoint.port.should == stale_endpoint.port
+      expect(cache.endpoint.host).to eq(stale_endpoint.host)
+      expect(cache.endpoint.port).to eq(stale_endpoint.port)
     end
   end
-  
 end

--- a/spec/endpoint_spec.rb
+++ b/spec/endpoint_spec.rb
@@ -1,16 +1,19 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 describe 'Dalli::Elasticache::AutoDiscovery::Endpoint' do
   let(:endpoint) do
-    Dalli::Elasticache::AutoDiscovery::Endpoint.new("my-cluster.cfg.use1.cache.amazonaws.com:11211")
+    Dalli::Elasticache::AutoDiscovery::Endpoint.new('my-cluster.cfg.use1.cache.amazonaws.com:11211')
   end
-  
+
   describe '.new' do
     it 'parses host' do
-      endpoint.host.should == "my-cluster.cfg.use1.cache.amazonaws.com"
+      expect(endpoint.host).to eq 'my-cluster.cfg.use1.cache.amazonaws.com'
     end
+
     it 'parses port' do
-      endpoint.port.should == 11211
+      expect(endpoint.port).to eq 11_211
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,7 @@
-require "bundler/setup"
+# frozen_string_literal: true
 
-require "dalli/elasticache"
+require 'bundler/setup'
 
-RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = :should
-  end
-  config.mock_with :rspec do |c|
-    c.syntax = :should
-  end
-end
+require 'dalli/elasticache'
+
+RSpec.configure

--- a/spec/stats_response_spec.rb
+++ b/spec/stats_response_spec.rb
@@ -1,14 +1,31 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 describe 'Dalli::Elasticache::AutoDiscovery::StatsResponse' do
-  let :response do
-    text = "STAT pid 1\r\nSTAT uptime 68717\r\nSTAT time 1398885375\r\nSTAT version 1.4.14\r\nSTAT libevent 1.4.13-stable\r\nSTAT pointer_size 64\r\nSTAT rusage_user 0.136008\r\nSTAT rusage_system 0.424026\r\nSTAT curr_connections 5\r\nSTAT total_connections 1159\r\nSTAT connection_structures 6\r\nSTAT reserved_fds 5\r\nSTAT cmd_get 0\r\nSTAT cmd_set 0\r\nSTAT cmd_flush 0\r\nSTAT cmd_touch 0\r\nSTAT cmd_config_get 4582\r\nSTAT cmd_config_set 2\r\nSTAT get_hits 0\r\nSTAT get_misses 0\r\nSTAT delete_misses 0\r\nSTAT delete_hits 0\r\nSTAT incr_misses 0\r\nSTAT incr_hits 0\r\nSTAT decr_misses 0\r\nSTAT decr_hits 0\r\nSTAT cas_misses 0\r\nSTAT cas_hits 0\r\nSTAT cas_badval 0\r\nSTAT touch_hits 0\r\nSTAT touch_misses 0\r\nSTAT auth_cmds 0\r\nSTAT auth_errors 0\r\nSTAT bytes_read 189356\r\nSTAT bytes_written 2906615\r\nSTAT limit_maxbytes 209715200\r\nSTAT accepting_conns 1\r\nSTAT listen_disabled_num 0\r\nSTAT threads 1\r\nSTAT conn_yields 0\r\nSTAT curr_config 1\r\nSTAT hash_power_level 16\r\nSTAT hash_bytes 524288\r\nSTAT hash_is_expanding 0\r\nSTAT expired_unfetched 0\r\nSTAT evicted_unfetched 0\r\nSTAT bytes 0\r\nSTAT curr_items 0\r\nSTAT total_items 0\r\nSTAT evictions 0\r\nSTAT reclaimed 0\r\n"
-    Dalli::Elasticache::AutoDiscovery::StatsResponse.new(text)
-  end
-  
+  let(:response) { Dalli::Elasticache::AutoDiscovery::StatsResponse.new(response_text) }
+
   describe '#version' do
+    let(:response_text) do
+      "STAT pid 1\r\nSTAT uptime 68717\r\nSTAT time 1398885375\r\nSTAT version 1.4.14\r\n"\
+        "STAT libevent 1.4.13-stable\r\nSTAT pointer_size 64\r\nSTAT rusage_user 0.136008\r\n"\
+        "STAT rusage_system 0.424026\r\nSTAT curr_connections 5\r\nSTAT total_connections 1159\r\n"\
+        "STAT connection_structures 6\r\nSTAT reserved_fds 5\r\nSTAT cmd_get 0\r\n"\
+        "STAT cmd_set 0\r\nSTAT cmd_flush 0\r\nSTAT cmd_touch 0\r\nSTAT cmd_config_get 4582\r\n"\
+        "STAT cmd_config_set 2\r\nSTAT get_hits 0\r\nSTAT get_misses 0\r\nSTAT delete_misses 0\r\n"\
+        "STAT delete_hits 0\r\nSTAT incr_misses 0\r\nSTAT incr_hits 0\r\nSTAT decr_misses 0\r\n"\
+        "STAT decr_hits 0\r\nSTAT cas_misses 0\r\nSTAT cas_hits 0\r\nSTAT cas_badval 0\r\n"\
+        "STAT touch_hits 0\r\nSTAT touch_misses 0\r\nSTAT auth_cmds 0\r\nSTAT auth_errors 0\r\n"\
+        "STAT bytes_read 189356\r\nSTAT bytes_written 2906615\r\nSTAT limit_maxbytes 209715200\r\n"\
+        "STAT accepting_conns 1\r\nSTAT listen_disabled_num 0\r\nSTAT threads 1\r\n"\
+        "STAT conn_yields 0\r\nSTAT curr_config 1\r\nSTAT hash_power_level 16\r\n"\
+        "STAT hash_bytes 524288\r\nSTAT hash_is_expanding 0\r\nSTAT expired_unfetched 0\r\n"\
+        "STAT evicted_unfetched 0\r\nSTAT bytes 0\r\nSTAT curr_items 0\r\nSTAT total_items 0\r\n"\
+        "STAT evictions 0\r\nSTAT reclaimed 0\r\n"
+    end
+
     it 'parses version' do
-      response.version.should == Gem::Version.new("1.4.14")
+      expect(response.version).to eq Gem::Version.new('1.4.14')
     end
   end
 end


### PR DESCRIPTION
This PR adds Rubocop and makes a number of changes to address open lints.

In addition it:

1. Sets the minimum Ruby version to 2.6, removing 2.5 and jruby-9.2 from the CI matrix.
2. Adds Ruby 3.1, jruby-9.3, ruby-head, and jruby-head to the CI matrix
3. Adds missing specs for the client method on Dalli::Elasticache
4. Adds a linting GitHub action