### PR TITLE
Refactor the code base to split up the Endpoint class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,6 @@ RSpec/MultipleExpectations:
 
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added 
+
+- Rubocop linting. [@petergoldstein](https://github.com/petergoldstein)
+- Specs for reading data off the socket, to ensure that code functions as expected. [@petergoldstein](https://github.com/petergoldstein)
+- This CHANGELOG.md. [@petergoldstein](https://github.com/petergoldstein)
+- Support for Google Memory Cloud. [@petergoldstein](https://github.com/petergoldstein)
+
+### Fixed
+
+- Parsing error when retrieving the version.  Version string is now parsed correctly. [@petergoldstein](https://github.com/petergoldstein)
+- Library would error when the engine version was non-numeric or included additional data.  Now treats such situations as a "modern" engine version. [@petergoldstein](https://github.com/petergoldstein)
+
+### Changed
+
+- BREAKING: engine_version is now returned as a string rather than a Gem::Version to support potentially non-numeric versions. [@petergoldstein](https://github.com/petergoldstein)
+- Updated README to reflect deprecation of DalliStore and preferred use of MemCacheStore. [@xiaoronglv](https://github.com/xiaoronglv)
+- Switched to GitHub Actions from Travis for CI. [@petergoldstein](https://github.com/petergoldstein)
+- Dalli::Elasticache now raises an ArgumentError if it cannot parse the config endpoint argument. [@petergoldstein](https://github.com/petergoldstein)
+- Now use default port of 11211 for configuration endpoint when not explicitly specified. [@petergoldstein](https://github.com/petergoldstein)
+- Refactored internal classes to better enable testing, shrink individual class responsibilities. [@petergoldstein](https://github.com/petergoldstein)
+
+### Removed
+
+- Support for all Rubies before 2.6 was dropped. [@petergoldstein](https://github.com/petergoldstein)
+
+
+## [0.2.0] - 2016-02-24
+
+### Changed
+
+- Node connections now use hostnames as opposed to IPs (which may change over time). [@BanjoInc](https://github.com/BanjoInc)
+- Ruby 2.2 and 2.3 was added to CI. [@ktheory](https://github.com/ktheory)
+
+### Removed
+
+- Support for Ruby 1.9.2 and 1.9.3 was dropped. [@ktheory](https://github.com/ktheory)
+
+## [0.1.2] - 2014-07-08
+
+### Changed
+
+- Added Ruby 2.0 and 2.1 to CI. [@petergoldstein](https://github.com/petergoldstein)
+
+### Fixed
+
+- Addressed NameError on refresh. [@ryo0301](https://github.com/ryo0301)
+
+## [0.1.1] - 2014-05-03
+
+### Added
+
+- Ability to retrieve configuration version (indication of how many times the node set has changed) from endpoint. [@zmillman](https://github.com/zmillman)
+- Specs for existing functionality. [@zmillman](https://github.com/zmillman)
+- Continuous Integration using Travis CI. [@zmillman](https://github.com/zmillman)
+- Refresh capability for the node set. [@zmillman](https://github.com/zmillman)
+
+### Changed
+
+- Refactoring and repackaging of the endpoint classes. [@zmillman](https://github.com/zmillman)
+
+
+## [0.1.0] - 2013-01-27
+
+### Added
+
+- Initial implementation for fetching node addresses from an Amazon ElastiCache endpoint. [@ktheory](https://github.com/ktheory)
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING: engine_version is now returned as a string rather than a Gem::Version to support potentially non-numeric versions. [@petergoldstein](https://github.com/petergoldstein)
 - Updated README to reflect deprecation of DalliStore and preferred use of MemCacheStore. [@xiaoronglv](https://github.com/xiaoronglv)
-- Switched to GitHub Actions from Travis for CI. [@petergoldstein](https://github.com/petergoldstein)
+- Switched to GitHub Actions from Travis for CI. Added Ruby 2.6, 2.7, 3.0, 3.1, ruby-head, jruby-9.3, jruby-head. [@petergoldstein](https://github.com/petergoldstein)
 - Dalli::Elasticache now raises an ArgumentError if it cannot parse the config endpoint argument. [@petergoldstein](https://github.com/petergoldstein)
 - Now use default port of 11211 for configuration endpoint when not explicitly specified. [@petergoldstein](https://github.com/petergoldstein)
 - Refactored internal classes to better enable testing, shrink individual class responsibilities. [@petergoldstein](https://github.com/petergoldstein)
+- Allow underscores in hostnames. 
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rubocop linting. [@petergoldstein](https://github.com/petergoldstein)
 - Specs for reading data off the socket, to ensure that code functions as expected. [@petergoldstein](https://github.com/petergoldstein)
 - This CHANGELOG.md. [@petergoldstein](https://github.com/petergoldstein)
-- Support for Google Memory Cloud. [@petergoldstein](https://github.com/petergoldstein)
+- Support for Google Cloud MemoryStore. [@petergoldstein](https://github.com/petergoldstein)
 
 ### Fixed
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (2017-2022) Aaron Suggs, Peter M. Goldstein
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Dalli ElastiCache [![Gem Version](https://badge.fury.io/rb/dalli-elasticache.svg)](http://badge.fury.io/rb/dalli-elasticache) [![Build Status](https://github.com/ktheory/dalli-elasticache/actions/workflows/tests.yml/badge.svg)](https://github.com/ktheory/dalli-elasticache/actions/workflows/tests.yml) [![Code Climate](https://codeclimate.com/github/ktheory/dalli-elasticache.png)](https://codeclimate.com/github/ktheory/dalli-elasticache)
 =================
 
-Use [AWS ElastiCache AutoDiscovery](http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html) to automatically configure your [Dalli memcached client](https://github.com/mperham/dalli) with all the nodes in your cluster.
+Use [AWS ElastiCache AutoDiscovery](http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html) to automatically configure your [Dalli memcached client](https://github.com/petergoldstein/dalli) with all the nodes in your cluster.
 
 Installation
 ------------
@@ -23,7 +23,7 @@ Configure your environment-specific application settings:
 endpoint    = "my-cluster-name.abc123.cfg.use1.cache.amazonaws.com:11211"
 elasticache = Dalli::ElastiCache.new(endpoint)
 
-config.cache_store = :mem_cache_store, elasticache.servers, {:expires_in => 1.day, :compress => true}
+config.cache_store = :mem_cache_store, elasticache.servers, { expires_in: 1.day, compress: true }
 ```
 
 Note that the ElastiCache server list will be refreshed each time an app server process starts.
@@ -38,9 +38,9 @@ config_endpoint = "aaron-scratch.vfdnac.cfg.use1.cache.amazonaws.com:11211"
 
 # Options for configuring the Dalli::Client
 dalli_options = {
-  :expires_in => 24 * 60 * 60,
-  :namespace => "my_app",
-  :compress => true
+  expires_in: 24 * 60 * 60,
+  namespace: "my_app",
+  compress: true
 }
 
 elasticache = Dalli::ElastiCache.new(config_endpoint, dalli_options)
@@ -75,6 +75,4 @@ elasticache.refresh.client
 License
 -------
 
-Copyright 2017 Aaron Suggs
-
-Released under an [MIT License](http://opensource.org/licenses/MIT)
+Copyright (2017-2022) Aaron Suggs, Peter M. Goldstein. See LICENSE for details.

--- a/dalli-elasticache.gemspec
+++ b/dalli-elasticache.gemspec
@@ -26,9 +26,10 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = '>= 2.6.0'
   s.required_rubygems_version = '>= 1.3.5'
 
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'faker', '~> 2.19'
+  s.add_development_dependency 'rake', '>= 13.0'
+  s.add_development_dependency 'rspec', '~> 3.10'
+  s.add_development_dependency 'rubocop', '~> 1.0'
   s.add_development_dependency 'rubocop-performance'
   s.add_development_dependency 'rubocop-rake'
   s.add_development_dependency 'rubocop-rspec'

--- a/lib/dalli/elasticache.rb
+++ b/lib/dalli/elasticache.rb
@@ -4,8 +4,12 @@ require 'dalli'
 require 'socket'
 require 'dalli/elasticache/version'
 require 'dalli/elasticache/auto_discovery/endpoint'
+require 'dalli/elasticache/auto_discovery/base_command'
+require 'dalli/elasticache/auto_discovery/node'
 require 'dalli/elasticache/auto_discovery/config_response'
+require 'dalli/elasticache/auto_discovery/config_command'
 require 'dalli/elasticache/auto_discovery/stats_response'
+require 'dalli/elasticache/auto_discovery/stats_command'
 
 module Dalli
   ##
@@ -47,6 +51,8 @@ module Dalli
     end
 
     # The cache engine version of the cluster
+    #
+    # Returns a string
     def engine_version
       endpoint.engine_version
     end
@@ -54,7 +60,7 @@ module Dalli
     # List of cluster server nodes with ip addresses and ports
     # Always use host name instead of private elasticache IPs as internal IPs can change after a node is rebooted
     def servers
-      endpoint.config.nodes.map { |h| "#{h[:host]}:#{h[:port]}" }
+      endpoint.config.nodes.map(&:to_s)
     end
 
     # Clear all cached data from the cluster endpoint

--- a/lib/dalli/elasticache/auto_discovery/base_command.rb
+++ b/lib/dalli/elasticache/auto_discovery/base_command.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Dalli
+  module Elasticache
+    module AutoDiscovery
+      ##
+      # Base command class for configuration endpoint
+      # command.  Contains the network logic.
+      ##
+      class BaseCommand
+        attr_reader :host, :port
+
+        def initialize(host, port)
+          @host = host
+          @port = port
+        end
+
+        # Send an ASCII command to the endpoint
+        #
+        # Returns the raw response as a String
+        def send_command
+          socket = TCPSocket.new(@host, @port)
+          begin
+            socket.puts command
+            response_from_socket(socket)
+          ensure
+            socket.close
+          end
+        end
+
+        def response_from_socket(socket)
+          data = +''
+          until (line = socket.readline).include?('END')
+            data << line
+          end
+
+          data
+        end
+      end
+    end
+  end
+end

--- a/lib/dalli/elasticache/auto_discovery/config_command.rb
+++ b/lib/dalli/elasticache/auto_discovery/config_command.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Dalli
+  module Elasticache
+    module AutoDiscovery
+      ##
+      # Encapsulates execution of the 'config' command, which is used to
+      # extract the list of nodes and determine if that list of nodes has changed.
+      ##
+      class ConfigCommand < BaseCommand
+        attr_reader :engine_version
+
+        CONFIG_COMMAND = "config get cluster\r\n"
+
+        # Legacy command for version < 1.4.14
+        LEGACY_CONFIG_COMMAND = "get AmazonElastiCache:cluster\r\n"
+
+        def initialize(host, port, engine_version)
+          super(host, port)
+          @engine_version = engine_version
+        end
+
+        def response
+          ConfigResponse.new(send_command)
+        end
+
+        def command
+          return LEGACY_CONFIG_COMMAND if legacy_config?
+
+          CONFIG_COMMAND
+        end
+
+        def legacy_config?
+          return false unless engine_version
+          return false if engine_version == 'unknown'
+
+          Gem::Version.new(engine_version) < Gem::Version.new('1.4.14')
+        rescue ArgumentError
+          # Just assume false if we can't parse the engine_version
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/dalli/elasticache/auto_discovery/config_command.rb
+++ b/lib/dalli/elasticache/auto_discovery/config_command.rb
@@ -32,7 +32,7 @@ module Dalli
 
         def legacy_config?
           return false unless engine_version
-          return false if engine_version == 'unknown'
+          return false if engine_version.casecmp('unknown').zero?
 
           Gem::Version.new(engine_version) < Gem::Version.new('1.4.14')
         rescue ArgumentError

--- a/lib/dalli/elasticache/auto_discovery/config_response.rb
+++ b/lib/dalli/elasticache/auto_discovery/config_response.rb
@@ -12,7 +12,7 @@ module Dalli
         attr_reader :text
 
         # Matches the version line of the response
-        VERSION_REGEX = /^(\d+)$/.freeze
+        VERSION_REGEX = /^(\d+)\r?\n/.freeze
 
         # Matches strings like "my-cluster.001.cache.aws.com|10.154.182.29|11211"
         NODE_REGEX = /(([-.a-zA-Z0-9]+)\|(\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b)\|(\d+))/.freeze
@@ -26,7 +26,10 @@ module Dalli
         #
         # Returns an integer
         def version
-          VERSION_REGEX.match(@text)[1].to_i
+          m = VERSION_REGEX.match(@text)
+          return -1 unless m
+
+          m[1].to_i
         end
 
         # Node hosts, ip addresses, and ports
@@ -34,11 +37,7 @@ module Dalli
         # Returns an Array of Hashes with values for :host, :ip and :port
         def nodes
           NODE_LIST_REGEX.match(@text).to_s.scan(NODE_REGEX).map do |match|
-            {
-              host: match[1],
-              ip: match[2],
-              port: match[3].to_i
-            }
+            Node.new(match[1], match[2], match[3].to_i)
           end
         end
       end

--- a/lib/dalli/elasticache/auto_discovery/endpoint.rb
+++ b/lib/dalli/elasticache/auto_discovery/endpoint.rb
@@ -13,7 +13,7 @@ module Dalli
         attr_reader :host, :port
 
         # Matches Strings like "my-host.cache.aws.com:11211"
-        ENDPOINT_REGEX = /([-.a-zA-Z0-9]+)(?::(\d+))?$/.freeze
+        ENDPOINT_REGEX = /^([-.a-zA-Z0-9]+)(?::(\d+))?$/.freeze
 
         def initialize(addr)
           @host, @port = parse_endpoint_address(addr)
@@ -24,7 +24,7 @@ module Dalli
           m = ENDPOINT_REGEX.match(addr)
           raise ArgumentError, "Unable to parse configuration endpoint address - #{addr}" unless m
 
-          [m[1], (m[2].to_i || DEFAULT_PORT)]
+          [m[1], (m[2] || DEFAULT_PORT).to_i]
         end
 
         # A cached ElastiCache::StatsResponse

--- a/lib/dalli/elasticache/auto_discovery/endpoint.rb
+++ b/lib/dalli/elasticache/auto_discovery/endpoint.rb
@@ -10,70 +10,36 @@ module Dalli
       ##
       class Endpoint
         # Endpoint configuration
-        attr_reader :host
-        attr_reader :port
+        attr_reader :host, :port
 
         # Matches Strings like "my-host.cache.aws.com:11211"
-        ENDPOINT_REGEX = /([-.a-zA-Z0-9]+):(\d+)/.freeze
+        ENDPOINT_REGEX = /([-.a-zA-Z0-9]+)(?::(\d+))?$/.freeze
 
-        STATS_COMMAND  = "stats\r\n"
-        CONFIG_COMMAND = "config get cluster\r\n"
+        def initialize(addr)
+          @host, @port = parse_endpoint_address(addr)
+        end
 
-        # Legacy command for version < 1.4.14
-        OLD_CONFIG_COMMAND = "get AmazonElastiCache:cluster\r\n"
+        DEFAULT_PORT = 11_211
+        def parse_endpoint_address(addr)
+          m = ENDPOINT_REGEX.match(addr)
+          raise ArgumentError, "Unable to parse configuration endpoint address - #{addr}" unless m
 
-        def initialize(endpoint)
-          ENDPOINT_REGEX.match(endpoint) do |m|
-            @host = m[1]
-            @port = m[2].to_i
-          end
+          [m[1], (m[2].to_i || DEFAULT_PORT)]
         end
 
         # A cached ElastiCache::StatsResponse
         def stats
-          @stats ||= stats_from_remote
+          @stats ||= StatsCommand.new(@host, @port).response
         end
 
         # A cached ElastiCache::ConfigResponse
         def config
-          @config ||= config_from_remote
+          @config ||= ConfigCommand.new(@host, @port, engine_version).response
         end
 
         # The memcached engine version
         def engine_version
-          stats.version
-        end
-
-        protected
-
-        def stats_from_remote
-          data = remote_command(STATS_COMMAND)
-          StatsResponse.new(data)
-        end
-
-        def config_from_remote
-          data = if engine_version < Gem::Version.new('1.4.14')
-                   remote_command(OLD_CONFIG_COMMAND)
-                 else
-                   remote_command(CONFIG_COMMAND)
-                 end
-          ConfigResponse.new(data)
-        end
-
-        # Send an ASCII command to the endpoint
-        #
-        # Returns the raw response as a String
-        def remote_command(command)
-          socket = TCPSocket.new(@host, @port)
-          socket.puts command
-
-          data = +''
-          until (line = socket.readline).include?('END')
-            data << line
-          end
-
-          socket.close
-          data
+          stats.engine_version
         end
       end
     end

--- a/lib/dalli/elasticache/auto_discovery/endpoint.rb
+++ b/lib/dalli/elasticache/auto_discovery/endpoint.rb
@@ -13,7 +13,7 @@ module Dalli
         attr_reader :host, :port
 
         # Matches Strings like "my-host.cache.aws.com:11211"
-        ENDPOINT_REGEX = /^([-.a-zA-Z0-9]+)(?::(\d+))?$/.freeze
+        ENDPOINT_REGEX = /^([-_.a-zA-Z0-9]+)(?::(\d+))?$/.freeze
 
         def initialize(addr)
           @host, @port = parse_endpoint_address(addr)

--- a/lib/dalli/elasticache/auto_discovery/node.rb
+++ b/lib/dalli/elasticache/auto_discovery/node.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Dalli
+  module Elasticache
+    module AutoDiscovery
+      ##
+      # Represents a single memcached node in the
+      # cluster.
+      ##
+      class Node
+        attr_reader :host, :ip, :port
+
+        def initialize(host, ip, port)
+          @host = host
+          @ip = ip
+          @port = port
+        end
+
+        def ==(other)
+          host == other.host &&
+            ip == other.ip &&
+            port == other.port
+        end
+
+        def eql?(other)
+          self == other
+        end
+
+        def hash
+          [host, ip, port].hash
+        end
+
+        def to_s
+          "#{@host}:#{@port}"
+        end
+      end
+    end
+  end
+end

--- a/lib/dalli/elasticache/auto_discovery/stats_command.rb
+++ b/lib/dalli/elasticache/auto_discovery/stats_command.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Dalli
+  module Elasticache
+    module AutoDiscovery
+      ##
+      # Encapsulates execution of the 'stats' command, which is used to
+      # extract the engine_version
+      ##
+      class StatsCommand < BaseCommand
+        STATS_COMMAND = "stats\r\n"
+
+        def response
+          StatsResponse.new(send_command)
+        end
+
+        def command
+          STATS_COMMAND
+        end
+      end
+    end
+  end
+end

--- a/lib/dalli/elasticache/auto_discovery/stats_response.rb
+++ b/lib/dalli/elasticache/auto_discovery/stats_response.rb
@@ -3,8 +3,9 @@
 module Dalli
   module Elasticache
     module AutoDiscovery
-      # This class wraps the raw ASCII response from an Auto Discovery endpoint
-      # and provides methods for extracting data from that response.
+      # This class wraps the raw ASCII response from a stats call to an
+      # Auto Discovery endpoint and provides methods for extracting data
+      # from that response.
       #
       # http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.AddingToYourClientLibrary.html
       class StatsResponse
@@ -12,7 +13,7 @@ module Dalli
         attr_reader :text
 
         # Matches the version line of the response
-        VERSION_REGEX = /^STAT version ([0-9.]+)\s*$/.freeze
+        VERSION_REGEX = /^STAT version ([0-9.]+|unknown)\s*/.freeze
 
         def initialize(response_text)
           @text = response_text.to_s
@@ -20,9 +21,12 @@ module Dalli
 
         # Extract the engine version stat
         #
-        # Returns a Gem::Version
-        def version
-          Gem::Version.new(VERSION_REGEX.match(@text)[1])
+        # Returns a string
+        def engine_version
+          m = VERSION_REGEX.match(@text)
+          return '' unless m && m[1]
+
+          m[1]
         end
       end
     end

--- a/lib/dalli/elasticache/auto_discovery/stats_response.rb
+++ b/lib/dalli/elasticache/auto_discovery/stats_response.rb
@@ -13,7 +13,7 @@ module Dalli
         attr_reader :text
 
         # Matches the version line of the response
-        VERSION_REGEX = /^STAT version ([0-9.]+|unknown)\s*/.freeze
+        VERSION_REGEX = /^STAT version ([0-9.]+|unknown)\s*/i.freeze
 
         def initialize(response_text)
           @text = response_text.to_s

--- a/spec/config_command_spec.rb
+++ b/spec/config_command_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+describe 'Dalli::Elasticache::AutoDiscovery::ConfigCommand' do
+  let(:host) { Faker::Internet.domain_name(subdomain: true) }
+  let(:port) { rand(1024..16_023) }
+  let(:command) { Dalli::Elasticache::AutoDiscovery::ConfigCommand.new(host, port, engine_version) }
+
+  let(:socket_response_lines) do
+    [
+      "CONFIG cluster 0 142\r\n",
+      "12\r\n",
+      'mycluster.0001.cache.amazonaws.com|10.112.21.1|11211 '\
+      'mycluster.0002.cache.amazonaws.com|10.112.21.2|11211 '\
+      "mycluster.0003.cache.amazonaws.com|10.112.21.3|11211\r\n",
+      "\r\n",
+      "END\r\n"
+    ]
+  end
+
+  let(:expected_nodes) do
+    [
+      Dalli::Elasticache::AutoDiscovery::Node.new('mycluster.0001.cache.amazonaws.com',
+                                                  '10.112.21.1',
+                                                  11_211),
+      Dalli::Elasticache::AutoDiscovery::Node.new('mycluster.0002.cache.amazonaws.com',
+                                                  '10.112.21.2',
+                                                  11_211),
+      Dalli::Elasticache::AutoDiscovery::Node.new('mycluster.0003.cache.amazonaws.com',
+                                                  '10.112.21.3',
+                                                  11_211)
+    ]
+  end
+
+  let(:mock_socket) { instance_double(TCPSocket) }
+
+  before do
+    allow(TCPSocket).to receive(:new).with(host, port).and_return(mock_socket)
+    allow(mock_socket).to receive(:close)
+    allow(mock_socket).to receive(:puts).with(cmd)
+    allow(mock_socket).to receive(:readline).and_return(*socket_response_lines)
+  end
+
+  context 'when the engine_version is 1.4.5' do
+    let(:engine_version) { '1.4.5' } # This is the only pre-1.4.14 version available on AWS
+    let(:cmd) { Dalli::Elasticache::AutoDiscovery::ConfigCommand::LEGACY_CONFIG_COMMAND }
+
+    context 'when the socket returns a valid response' do
+      before do
+        allow(mock_socket).to receive(:readline).and_return(*socket_response_lines)
+      end
+
+      it 'sends the legacy command and returns a ConfigResponse with expected values' do
+        response = command.response
+        expect(response).to be_a Dalli::Elasticache::AutoDiscovery::ConfigResponse
+        expect(response.version).to eq(12)
+        expect(response.nodes).to eq(expected_nodes)
+        expect(mock_socket).to have_received(:close)
+      end
+    end
+  end
+
+  context 'when the engine_version is greater than or equal to 1.4.14' do
+    let(:engine_version) { ['1.4.14', '1.5.6', '1.6.10'].sample }
+    let(:cmd) { Dalli::Elasticache::AutoDiscovery::ConfigCommand::CONFIG_COMMAND }
+
+    context 'when the socket returns a valid response' do
+      before do
+        allow(mock_socket).to receive(:readline).and_return(*socket_response_lines)
+      end
+
+      it 'sends the current command and returns a ConfigResponse with expected values' do
+        response = command.response
+        expect(response).to be_a Dalli::Elasticache::AutoDiscovery::ConfigResponse
+        expect(response.version).to eq(12)
+        expect(response.nodes).to eq(expected_nodes)
+        expect(mock_socket).to have_received(:close)
+      end
+    end
+  end
+
+  context 'when the engine_version is unknown or some other string' do
+    let(:engine_version) { ['unknown', SecureRandom.hex(4), nil].sample }
+    let(:cmd) { Dalli::Elasticache::AutoDiscovery::ConfigCommand::CONFIG_COMMAND }
+
+    context 'when the socket returns a valid response' do
+      before do
+        allow(mock_socket).to receive(:readline).and_return(*socket_response_lines)
+      end
+
+      it 'sends the current command and returns a ConfigResponse with expected values' do
+        response = command.response
+        expect(response).to be_a Dalli::Elasticache::AutoDiscovery::ConfigResponse
+        expect(response.version).to eq(12)
+        expect(response.nodes).to eq(expected_nodes)
+        expect(mock_socket).to have_received(:close)
+      end
+    end
+  end
+end

--- a/spec/config_command_spec.rb
+++ b/spec/config_command_spec.rb
@@ -80,8 +80,8 @@ describe 'Dalli::Elasticache::AutoDiscovery::ConfigCommand' do
     end
   end
 
-  context 'when the engine_version is unknown or some other string' do
-    let(:engine_version) { ['unknown', SecureRandom.hex(4), nil].sample }
+  context 'when the engine_version is UNKNOWN or some other string' do
+    let(:engine_version) { ['UNKNOWN', SecureRandom.hex(4), nil].sample }
     let(:cmd) { Dalli::Elasticache::AutoDiscovery::ConfigCommand::CONFIG_COMMAND }
 
     context 'when the socket returns a valid response' do

--- a/spec/config_response_spec.rb
+++ b/spec/config_response_spec.rb
@@ -18,7 +18,7 @@ describe 'Dalli::Elasticache::AutoDiscovery::ConfigResponse' do
 
   describe '#nodes' do
     it 'parses hosts' do
-      expect(response.nodes.map { |s| s[:host] }).to eq [
+      expect(response.nodes.map(&:host)).to eq [
         'mycluster.0001.cache.amazonaws.com',
         'mycluster.0002.cache.amazonaws.com',
         'mycluster.0003.cache.amazonaws.com'
@@ -26,11 +26,11 @@ describe 'Dalli::Elasticache::AutoDiscovery::ConfigResponse' do
     end
 
     it 'parses ip addresses' do
-      expect(response.nodes.map { |s| s[:ip] }).to eq ['10.112.21.1', '10.112.21.2', '10.112.21.3']
+      expect(response.nodes.map(&:ip)).to eq ['10.112.21.1', '10.112.21.2', '10.112.21.3']
     end
 
     it 'parses ports' do
-      expect(response.nodes.map { |s| s[:port] }).to eq [11_211, 11_211, 11_211]
+      expect(response.nodes.map(&:port)).to eq [11_211, 11_211, 11_211]
     end
   end
 end

--- a/spec/elasticache_spec.rb
+++ b/spec/elasticache_spec.rb
@@ -11,7 +11,9 @@ describe 'Dalli::ElastiCache::Endpoint' do
     }
   end
 
-  let(:config_endpoint) { 'my-cluster.cfg.use1.cache.amazonaws.com:11211' }
+  let(:host) { 'my-cluster.cfg.use1.cache.amazonaws.com' }
+  let(:port) { 11_211 }
+  let(:config_endpoint) { "#{host}:#{port}" }
   let(:cache) do
     Dalli::ElastiCache.new(config_endpoint, dalli_options)
   end
@@ -44,7 +46,7 @@ describe 'Dalli::ElastiCache::Endpoint' do
     before do
       allow(Dalli::Elasticache::AutoDiscovery::Endpoint).to receive(:new)
         .with(config_endpoint).and_return(stub_endpoint)
-      allow(stub_endpoint).to receive(:config_from_remote).and_return(response)
+      allow(stub_endpoint).to receive(:config).and_return(response)
       allow(Dalli::Client).to receive(:new)
         .with(['mycluster.0001.cache.amazonaws.com:11211',
                'mycluster.0002.cache.amazonaws.com:11211',
@@ -54,7 +56,7 @@ describe 'Dalli::ElastiCache::Endpoint' do
 
     it 'builds with node list and dalli options' do
       expect(client).to eq(mock_dalli)
-      expect(stub_endpoint).to have_received(:config_from_remote)
+      expect(stub_endpoint).to have_received(:config)
       expect(Dalli::Client).to have_received(:new)
         .with(['mycluster.0001.cache.amazonaws.com:11211',
                'mycluster.0002.cache.amazonaws.com:11211',
@@ -69,14 +71,14 @@ describe 'Dalli::ElastiCache::Endpoint' do
     before do
       allow(Dalli::Elasticache::AutoDiscovery::Endpoint).to receive(:new)
         .with(config_endpoint).and_return(stub_endpoint)
-      allow(stub_endpoint).to receive(:config_from_remote).and_return(response)
+      allow(stub_endpoint).to receive(:config).and_return(response)
     end
 
     it 'lists addresses and ports' do
       expect(cache.servers).to eq ['mycluster.0001.cache.amazonaws.com:11211',
                                    'mycluster.0002.cache.amazonaws.com:11211',
                                    'mycluster.0003.cache.amazonaws.com:11211']
-      expect(stub_endpoint).to have_received(:config_from_remote)
+      expect(stub_endpoint).to have_received(:config)
       expect(Dalli::Elasticache::AutoDiscovery::Endpoint).to have_received(:new).with(config_endpoint)
     end
   end

--- a/spec/endpoint_spec.rb
+++ b/spec/endpoint_spec.rb
@@ -20,7 +20,7 @@ describe 'Dalli::Elasticache::AutoDiscovery::Endpoint' do
       end
     end
 
-    context 'when the string includes both only a host' do
+    context 'when the string includes only a host' do
       let(:arg_string) { 'example.cfg.use1.cache.amazonaws.com' }
 
       it 'parses host' do
@@ -69,6 +69,18 @@ describe 'Dalli::Elasticache::AutoDiscovery::Endpoint' do
         expect do
           endpoint
         end.to raise_error ArgumentError, "Unable to parse configuration endpoint address - #{arg_string}"
+      end
+    end
+
+    context 'when the host in the string includes an underscore' do
+      let(:arg_string) { 'my_cluster.cfg.use1.cache.amazonaws.com:12345' }
+
+      it 'parses host' do
+        expect(endpoint.host).to eq 'my_cluster.cfg.use1.cache.amazonaws.com'
+      end
+
+      it 'parses port' do
+        expect(endpoint.port).to eq 12_345
       end
     end
   end

--- a/spec/endpoint_spec.rb
+++ b/spec/endpoint_spec.rb
@@ -4,16 +4,72 @@ require_relative 'spec_helper'
 
 describe 'Dalli::Elasticache::AutoDiscovery::Endpoint' do
   let(:endpoint) do
-    Dalli::Elasticache::AutoDiscovery::Endpoint.new('my-cluster.cfg.use1.cache.amazonaws.com:11211')
+    Dalli::Elasticache::AutoDiscovery::Endpoint.new(arg_string)
   end
 
   describe '.new' do
-    it 'parses host' do
-      expect(endpoint.host).to eq 'my-cluster.cfg.use1.cache.amazonaws.com'
+    context 'when the string includes both host and port' do
+      let(:arg_string) { 'my-cluster.cfg.use1.cache.amazonaws.com:12345' }
+
+      it 'parses host' do
+        expect(endpoint.host).to eq 'my-cluster.cfg.use1.cache.amazonaws.com'
+      end
+
+      it 'parses port' do
+        expect(endpoint.port).to eq 12_345
+      end
     end
 
-    it 'parses port' do
-      expect(endpoint.port).to eq 11_211
+    context 'when the string includes both only a host' do
+      let(:arg_string) { 'example.cfg.use1.cache.amazonaws.com' }
+
+      it 'parses host' do
+        expect(endpoint.host).to eq 'example.cfg.use1.cache.amazonaws.com'
+      end
+
+      it 'parses port' do
+        expect(endpoint.port).to eq 11_211
+      end
+    end
+
+    context 'when the string is nil' do
+      let(:arg_string) { nil }
+
+      it 'raises ArgumentError' do
+        expect do
+          endpoint
+        end.to raise_error ArgumentError, "Unable to parse configuration endpoint address - #{arg_string}"
+      end
+    end
+
+    context 'when the string contains disallowed characters in the host' do
+      let(:arg_string) { 'my-cluster?.cfg.use1.cache.amazonaws.com:12345' }
+
+      it 'raises ArgumentError' do
+        expect do
+          endpoint
+        end.to raise_error ArgumentError, "Unable to parse configuration endpoint address - #{arg_string}"
+      end
+    end
+
+    context 'when the string contains disallowed characters in the port' do
+      let(:arg_string) { 'my-cluster.cfg.use1.cache.amazonaws.com:1234a5' }
+
+      it 'raises ArgumentError' do
+        expect do
+          endpoint
+        end.to raise_error ArgumentError, "Unable to parse configuration endpoint address - #{arg_string}"
+      end
+    end
+
+    context 'when the string contains trailing characters' do
+      let(:arg_string) { 'my-cluster.cfg.use1.cache.amazonaws.com:12345abcd' }
+
+      it 'raises ArgumentError' do
+        expect do
+          endpoint
+        end.to raise_error ArgumentError, "Unable to parse configuration endpoint address - #{arg_string}"
+      end
     end
   end
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+describe 'Dalli::Elasticache::AutoDiscovery::Node' do
+  context 'when comparing with equals' do
+    let(:host1) { Faker::Internet.domain_name(subdomain: true) }
+    let(:ip1) { Faker::Internet.public_ip_v4_address }
+    let(:port1) { rand(1024..16_023) }
+    let(:host2) { Faker::Internet.domain_name(subdomain: true) }
+    let(:ip2) { Faker::Internet.public_ip_v4_address }
+    let(:port2) { rand(1024..16_023) }
+
+    let(:node1a) { Dalli::Elasticache::AutoDiscovery::Node.new(host1, ip1, port1) }
+    let(:node1b) { Dalli::Elasticache::AutoDiscovery::Node.new(host1, ip1, port1) }
+
+    let(:node_with_different_host) { Dalli::Elasticache::AutoDiscovery::Node.new(host2, ip1, port1) }
+    let(:node_with_different_ip) { Dalli::Elasticache::AutoDiscovery::Node.new(host1, ip2, port1) }
+    let(:node_with_different_port) { Dalli::Elasticache::AutoDiscovery::Node.new(host1, ip1, port2) }
+
+    it 'is equal to a value with the same values' do
+      expect(node1a).to eq(node1b)
+      expect(node1a.eql?(node1b)).to eq(true)
+    end
+
+    it 'is not equal to a value with any differing values' do
+      expect(node1a).not_to eq(node_with_different_host)
+      expect(node1a.eql?(node_with_different_host)).to eq(false)
+      expect(node1a).not_to eq(node_with_different_ip)
+      expect(node1a.eql?(node_with_different_ip)).to eq(false)
+      expect(node1a).not_to eq(node_with_different_port)
+      expect(node1a.eql?(node_with_different_port)).to eq(false)
+    end
+  end
+
+  context 'when used as a hash key' do
+    let(:host1) { Faker::Internet.domain_name(subdomain: true) }
+    let(:ip1) { Faker::Internet.public_ip_v4_address }
+    let(:port1) { rand(1024..16_023) }
+    let(:host2) { Faker::Internet.domain_name(subdomain: true) }
+    let(:ip2) { Faker::Internet.public_ip_v4_address }
+    let(:port2) { rand(1024..16_023) }
+
+    let(:node1a) { Dalli::Elasticache::AutoDiscovery::Node.new(host1, ip1, port1) }
+    let(:node1b) { Dalli::Elasticache::AutoDiscovery::Node.new(host1, ip1, port1) }
+
+    let(:node_with_different_host) { Dalli::Elasticache::AutoDiscovery::Node.new(host2, ip1, port1) }
+    let(:node_with_different_ip) { Dalli::Elasticache::AutoDiscovery::Node.new(host1, ip2, port1) }
+    let(:node_with_different_port) { Dalli::Elasticache::AutoDiscovery::Node.new(host1, ip1, port2) }
+
+    let(:test_val) { 'abcd' }
+    let(:test_hash) do
+      { node1a => test_val }
+    end
+
+    it 'computes the same hash key' do
+      expect(node1a.hash).to eq(node1b.hash)
+    end
+
+    it 'matches when an equivalent object is used' do
+      expect(test_hash.key?(node1b)).to eq(true)
+    end
+
+    it 'does not match when an non-equivalent object is used' do
+      expect(test_hash.key?(node_with_different_host)).to eq(false)
+      expect(test_hash.key?(node_with_different_ip)).to eq(false)
+      expect(test_hash.key?(node_with_different_port)).to eq(false)
+    end
+  end
+
+  describe '#to_s' do
+    let(:host) { Faker::Internet.domain_name(subdomain: true) }
+    let(:ip) { Faker::Internet.public_ip_v4_address }
+    let(:port) { rand(1024..16_023) }
+
+    let(:node) { Dalli::Elasticache::AutoDiscovery::Node.new(host, ip, port) }
+
+    it 'returns the expected string value' do
+      expect(node.to_s).to eq("#{host}:#{port}")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,5 +3,7 @@
 require 'bundler/setup'
 
 require 'dalli/elasticache'
+require 'securerandom'
+require 'faker'
 
 RSpec.configure

--- a/spec/stats_command_spec.rb
+++ b/spec/stats_command_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+describe 'Dalli::Elasticache::AutoDiscovery::StatsCommand' do
+  let(:host) { 'example.com' }
+  let(:port) { 12_345 }
+  let(:command) { Dalli::Elasticache::AutoDiscovery::StatsCommand.new(host, port) }
+  let(:engine_version) { ['1.4.5', '1.4.14', '1.5.6', '1.6.10'].sample }
+  let(:cmd) { "stats\r\n" }
+
+  let(:socket_response_lines) do
+    [
+      "STAT pid 1\r\n",
+      "STAT uptime 68717\r\n",
+      "STAT time 1398885375\r\n",
+      "STAT version #{engine_version}\r\n",
+      "STAT libevent 1.4.13-stable\r\n",
+      "STAT pointer_size 64\r\n",
+      "STAT rusage_user 0.136008\r\n",
+      "STAT rusage_system 0.424026\r\n",
+      "STAT curr_connections 5\r\n",
+      "STAT total_connections 1159\r\n",
+      "STAT connection_structures 6\r\n",
+      "STAT reserved_fds 5\r\n",
+      "STAT cmd_get 0\r\n",
+      "STAT cmd_set 0\r\n",
+      "STAT cmd_flush 0\r\n",
+      "STAT cmd_touch 0\r\n",
+      "STAT cmd_config_get 4582\r\n",
+      "STAT cmd_config_set 2\r\n",
+      "STAT get_hits 0\r\n",
+      "STAT get_misses 0\r\n",
+      "STAT delete_misses 0\r\n",
+      "STAT delete_hits 0\r\n",
+      "STAT incr_misses 0\r\n",
+      "STAT incr_hits 0\r\n",
+      "STAT decr_misses 0\r\n",
+      "STAT decr_hits 0\r\n",
+      "STAT cas_misses 0\r\n",
+      "STAT cas_hits 0\r\n",
+      "STAT cas_badval 0\r\n",
+      "STAT touch_hits 0\r\n",
+      "STAT touch_misses 0\r\n",
+      "STAT auth_cmds 0\r\n",
+      "STAT auth_errors 0\r\n",
+      "STAT bytes_read 189356\r\n",
+      "STAT bytes_written 2906615\r\n",
+      "STAT limit_maxbytes 209715200\r\n",
+      "STAT accepting_conns 1\r\n",
+      "STAT listen_disabled_num 0\r\n",
+      "STAT threads 1\r\n",
+      "STAT conn_yields 0\r\n",
+      "STAT curr_config 1\r\n",
+      "STAT hash_power_level 16\r\n",
+      "STAT hash_bytes 524288\r\n",
+      "STAT hash_is_expanding 0\r\n",
+      "STAT expired_unfetched 0\r\n",
+      "STAT evicted_unfetched 0\r\n",
+      "STAT bytes 0\r\n",
+      "STAT curr_items 0\r\n",
+      "STAT total_items 0\r\n",
+      "STAT evictions 0\r\n",
+      "STAT reclaimed 0\r\n",
+      "END\r\n"
+    ]
+  end
+
+  let(:mock_socket) { instance_double(TCPSocket) }
+
+  before do
+    allow(TCPSocket).to receive(:new).with(host, port).and_return(mock_socket)
+    allow(mock_socket).to receive(:close)
+    allow(mock_socket).to receive(:puts).with(cmd)
+    allow(mock_socket).to receive(:readline).and_return(*socket_response_lines)
+  end
+
+  context 'when the socket returns a valid response' do
+    before do
+      allow(mock_socket).to receive(:readline).and_return(*socket_response_lines)
+    end
+
+    it 'sends the command and parses out the engine version' do
+      response = command.response
+      expect(response.engine_version).to eq(engine_version)
+      expect(mock_socket).to have_received(:close)
+      expect(mock_socket).to have_received(:puts).with(cmd)
+    end
+  end
+end

--- a/spec/stats_response_spec.rb
+++ b/spec/stats_response_spec.rb
@@ -5,27 +5,113 @@ require_relative 'spec_helper'
 describe 'Dalli::Elasticache::AutoDiscovery::StatsResponse' do
   let(:response) { Dalli::Elasticache::AutoDiscovery::StatsResponse.new(response_text) }
 
-  describe '#version' do
-    let(:response_text) do
-      "STAT pid 1\r\nSTAT uptime 68717\r\nSTAT time 1398885375\r\nSTAT version 1.4.14\r\n"\
-        "STAT libevent 1.4.13-stable\r\nSTAT pointer_size 64\r\nSTAT rusage_user 0.136008\r\n"\
-        "STAT rusage_system 0.424026\r\nSTAT curr_connections 5\r\nSTAT total_connections 1159\r\n"\
-        "STAT connection_structures 6\r\nSTAT reserved_fds 5\r\nSTAT cmd_get 0\r\n"\
-        "STAT cmd_set 0\r\nSTAT cmd_flush 0\r\nSTAT cmd_touch 0\r\nSTAT cmd_config_get 4582\r\n"\
-        "STAT cmd_config_set 2\r\nSTAT get_hits 0\r\nSTAT get_misses 0\r\nSTAT delete_misses 0\r\n"\
-        "STAT delete_hits 0\r\nSTAT incr_misses 0\r\nSTAT incr_hits 0\r\nSTAT decr_misses 0\r\n"\
-        "STAT decr_hits 0\r\nSTAT cas_misses 0\r\nSTAT cas_hits 0\r\nSTAT cas_badval 0\r\n"\
-        "STAT touch_hits 0\r\nSTAT touch_misses 0\r\nSTAT auth_cmds 0\r\nSTAT auth_errors 0\r\n"\
-        "STAT bytes_read 189356\r\nSTAT bytes_written 2906615\r\nSTAT limit_maxbytes 209715200\r\n"\
-        "STAT accepting_conns 1\r\nSTAT listen_disabled_num 0\r\nSTAT threads 1\r\n"\
-        "STAT conn_yields 0\r\nSTAT curr_config 1\r\nSTAT hash_power_level 16\r\n"\
-        "STAT hash_bytes 524288\r\nSTAT hash_is_expanding 0\r\nSTAT expired_unfetched 0\r\n"\
-        "STAT evicted_unfetched 0\r\nSTAT bytes 0\r\nSTAT curr_items 0\r\nSTAT total_items 0\r\n"\
-        "STAT evictions 0\r\nSTAT reclaimed 0\r\n"
+  describe '#engine_version' do
+    context 'when the version number is a number' do
+      let(:engine_version) { ['1.4.14', '1.5.6', '1.6.10'].sample }
+
+      context 'when the response with the version stat only includes the version number' do
+        let(:response_text) do
+          "STAT pid 1\r\nSTAT uptime 68717\r\nSTAT time 1398885375\r\n"\
+            "STAT version #{engine_version}\r\n"\
+            "STAT libevent 1.4.13-stable\r\nSTAT pointer_size 64\r\nSTAT rusage_user 0.136008\r\n"\
+            "STAT rusage_system 0.424026\r\nSTAT curr_connections 5\r\nSTAT total_connections 1159\r\n"\
+            "STAT connection_structures 6\r\nSTAT reserved_fds 5\r\nSTAT cmd_get 0\r\n"\
+            "STAT cmd_set 0\r\nSTAT cmd_flush 0\r\nSTAT cmd_touch 0\r\nSTAT cmd_config_get 4582\r\n"\
+            "STAT cmd_config_set 2\r\nSTAT get_hits 0\r\nSTAT get_misses 0\r\nSTAT delete_misses 0\r\n"\
+            "STAT delete_hits 0\r\nSTAT incr_misses 0\r\nSTAT incr_hits 0\r\nSTAT decr_misses 0\r\n"\
+            "STAT decr_hits 0\r\nSTAT cas_misses 0\r\nSTAT cas_hits 0\r\nSTAT cas_badval 0\r\n"\
+            "STAT touch_hits 0\r\nSTAT touch_misses 0\r\nSTAT auth_cmds 0\r\nSTAT auth_errors 0\r\n"\
+            "STAT bytes_read 189356\r\nSTAT bytes_written 2906615\r\nSTAT limit_maxbytes 209715200\r\n"\
+            "STAT accepting_conns 1\r\nSTAT listen_disabled_num 0\r\nSTAT threads 1\r\n"\
+            "STAT conn_yields 0\r\nSTAT curr_config 1\r\nSTAT hash_power_level 16\r\n"\
+            "STAT hash_bytes 524288\r\nSTAT hash_is_expanding 0\r\nSTAT expired_unfetched 0\r\n"\
+            "STAT evicted_unfetched 0\r\nSTAT bytes 0\r\nSTAT curr_items 0\r\nSTAT total_items 0\r\n"\
+            "STAT evictions 0\r\nSTAT reclaimed 0\r\n"
+        end
+
+        it 'parses out the engine version' do
+          expect(response.engine_version).to eq engine_version
+        end
+      end
+
+      context 'when the response with the version stat includes the version number and trailing text' do
+        let(:response_text) do
+          "STAT pid 1\r\nSTAT uptime 68717\r\nSTAT time 1398885375\r\n"\
+            "STAT version #{engine_version} #{SecureRandom.hex(5)}\r\n"\
+            "STAT libevent 1.4.13-stable\r\nSTAT pointer_size 64\r\nSTAT rusage_user 0.136008\r\n"\
+            "STAT rusage_system 0.424026\r\nSTAT curr_connections 5\r\nSTAT total_connections 1159\r\n"\
+            "STAT connection_structures 6\r\nSTAT reserved_fds 5\r\nSTAT cmd_get 0\r\n"\
+            "STAT cmd_set 0\r\nSTAT cmd_flush 0\r\nSTAT cmd_touch 0\r\nSTAT cmd_config_get 4582\r\n"\
+            "STAT cmd_config_set 2\r\nSTAT get_hits 0\r\nSTAT get_misses 0\r\nSTAT delete_misses 0\r\n"\
+            "STAT delete_hits 0\r\nSTAT incr_misses 0\r\nSTAT incr_hits 0\r\nSTAT decr_misses 0\r\n"\
+            "STAT decr_hits 0\r\nSTAT cas_misses 0\r\nSTAT cas_hits 0\r\nSTAT cas_badval 0\r\n"\
+            "STAT touch_hits 0\r\nSTAT touch_misses 0\r\nSTAT auth_cmds 0\r\nSTAT auth_errors 0\r\n"\
+            "STAT bytes_read 189356\r\nSTAT bytes_written 2906615\r\nSTAT limit_maxbytes 209715200\r\n"\
+            "STAT accepting_conns 1\r\nSTAT listen_disabled_num 0\r\nSTAT threads 1\r\n"\
+            "STAT conn_yields 0\r\nSTAT curr_config 1\r\nSTAT hash_power_level 16\r\n"\
+            "STAT hash_bytes 524288\r\nSTAT hash_is_expanding 0\r\nSTAT expired_unfetched 0\r\n"\
+            "STAT evicted_unfetched 0\r\nSTAT bytes 0\r\nSTAT curr_items 0\r\nSTAT total_items 0\r\n"\
+            "STAT evictions 0\r\nSTAT reclaimed 0\r\n"
+        end
+
+        it 'parses out the engine version' do
+          expect(response.engine_version).to eq engine_version
+        end
+      end
     end
 
-    it 'parses version' do
-      expect(response.version).to eq Gem::Version.new('1.4.14')
+    context "when the version number is the string 'unknown'" do
+      let(:engine_version) { 'unknown' }
+
+      context 'when the response with the version stat only includes the version number' do
+        let(:response_text) do
+          "STAT pid 1\r\nSTAT uptime 68717\r\nSTAT time 1398885375\r\n"\
+            "STAT version #{engine_version}\r\n"\
+            "STAT libevent 1.4.13-stable\r\nSTAT pointer_size 64\r\nSTAT rusage_user 0.136008\r\n"\
+            "STAT rusage_system 0.424026\r\nSTAT curr_connections 5\r\nSTAT total_connections 1159\r\n"\
+            "STAT connection_structures 6\r\nSTAT reserved_fds 5\r\nSTAT cmd_get 0\r\n"\
+            "STAT cmd_set 0\r\nSTAT cmd_flush 0\r\nSTAT cmd_touch 0\r\nSTAT cmd_config_get 4582\r\n"\
+            "STAT cmd_config_set 2\r\nSTAT get_hits 0\r\nSTAT get_misses 0\r\nSTAT delete_misses 0\r\n"\
+            "STAT delete_hits 0\r\nSTAT incr_misses 0\r\nSTAT incr_hits 0\r\nSTAT decr_misses 0\r\n"\
+            "STAT decr_hits 0\r\nSTAT cas_misses 0\r\nSTAT cas_hits 0\r\nSTAT cas_badval 0\r\n"\
+            "STAT touch_hits 0\r\nSTAT touch_misses 0\r\nSTAT auth_cmds 0\r\nSTAT auth_errors 0\r\n"\
+            "STAT bytes_read 189356\r\nSTAT bytes_written 2906615\r\nSTAT limit_maxbytes 209715200\r\n"\
+            "STAT accepting_conns 1\r\nSTAT listen_disabled_num 0\r\nSTAT threads 1\r\n"\
+            "STAT conn_yields 0\r\nSTAT curr_config 1\r\nSTAT hash_power_level 16\r\n"\
+            "STAT hash_bytes 524288\r\nSTAT hash_is_expanding 0\r\nSTAT expired_unfetched 0\r\n"\
+            "STAT evicted_unfetched 0\r\nSTAT bytes 0\r\nSTAT curr_items 0\r\nSTAT total_items 0\r\n"\
+            "STAT evictions 0\r\nSTAT reclaimed 0\r\n"
+        end
+
+        it "parses out the engine version as 'unknown'" do
+          expect(response.engine_version).to eq engine_version
+        end
+      end
+
+      context 'when the response with the version stat includes the version number and trailing text' do
+        let(:response_text) do
+          "STAT pid 1\r\nSTAT uptime 68717\r\nSTAT time 1398885375\r\n"\
+            "STAT version #{engine_version} #{SecureRandom.hex(5)}\r\n"\
+            "STAT libevent 1.4.13-stable\r\nSTAT pointer_size 64\r\nSTAT rusage_user 0.136008\r\n"\
+            "STAT rusage_system 0.424026\r\nSTAT curr_connections 5\r\nSTAT total_connections 1159\r\n"\
+            "STAT connection_structures 6\r\nSTAT reserved_fds 5\r\nSTAT cmd_get 0\r\n"\
+            "STAT cmd_set 0\r\nSTAT cmd_flush 0\r\nSTAT cmd_touch 0\r\nSTAT cmd_config_get 4582\r\n"\
+            "STAT cmd_config_set 2\r\nSTAT get_hits 0\r\nSTAT get_misses 0\r\nSTAT delete_misses 0\r\n"\
+            "STAT delete_hits 0\r\nSTAT incr_misses 0\r\nSTAT incr_hits 0\r\nSTAT decr_misses 0\r\n"\
+            "STAT decr_hits 0\r\nSTAT cas_misses 0\r\nSTAT cas_hits 0\r\nSTAT cas_badval 0\r\n"\
+            "STAT touch_hits 0\r\nSTAT touch_misses 0\r\nSTAT auth_cmds 0\r\nSTAT auth_errors 0\r\n"\
+            "STAT bytes_read 189356\r\nSTAT bytes_written 2906615\r\nSTAT limit_maxbytes 209715200\r\n"\
+            "STAT accepting_conns 1\r\nSTAT listen_disabled_num 0\r\nSTAT threads 1\r\n"\
+            "STAT conn_yields 0\r\nSTAT curr_config 1\r\nSTAT hash_power_level 16\r\n"\
+            "STAT hash_bytes 524288\r\nSTAT hash_is_expanding 0\r\nSTAT expired_unfetched 0\r\n"\
+            "STAT evicted_unfetched 0\r\nSTAT bytes 0\r\nSTAT curr_items 0\r\nSTAT total_items 0\r\n"\
+            "STAT evictions 0\r\nSTAT reclaimed 0\r\n"
+        end
+
+        it "parses out the engine version as 'unknown'" do
+          expect(response.engine_version).to eq engine_version
+        end
+      end
     end
   end
 end

--- a/spec/stats_response_spec.rb
+++ b/spec/stats_response_spec.rb
@@ -61,7 +61,7 @@ describe 'Dalli::Elasticache::AutoDiscovery::StatsResponse' do
     end
 
     context "when the version number is the string 'unknown'" do
-      let(:engine_version) { 'unknown' }
+      let(:engine_version) { 'UNKNOWN' }
 
       context 'when the response with the version stat only includes the version number' do
         let(:response_text) do
@@ -83,7 +83,7 @@ describe 'Dalli::Elasticache::AutoDiscovery::StatsResponse' do
             "STAT evictions 0\r\nSTAT reclaimed 0\r\n"
         end
 
-        it "parses out the engine version as 'unknown'" do
+        it "parses out the engine version as 'UNKNOWN'" do
           expect(response.engine_version).to eq engine_version
         end
       end
@@ -108,7 +108,7 @@ describe 'Dalli::Elasticache::AutoDiscovery::StatsResponse' do
             "STAT evictions 0\r\nSTAT reclaimed 0\r\n"
         end
 
-        it "parses out the engine version as 'unknown'" do
+        it "parses out the engine version as 'UNKNOWN'" do
           expect(response.engine_version).to eq engine_version
         end
       end


### PR DESCRIPTION
In addition:

1. Added socket level tests to ensure data provided from socket is processed correctly
2. Discovered and resolved response parsing bug on version (the carriage return was not being handled)
3. Changed the engine_version methods to return a string, to allow non-numeric values (like 'unknown')
4. Added handling for 'unknown' as an engine_version, to enable support for Google Cloud
5. Updated the regexp to ignore text after the engine_version in the stat line.
6. Made the port for the configuration optional, with a default of 11211
7. Added CHANGELOG.md and LICENSE file.  Minor updates to README.md