### PR TITLE
Use correct path to elasticache file

### DIFF
--- a/lib/dalli-elasticache.rb
+++ b/lib/dalli-elasticache.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 # Support default bundler require path
-require_relative 'elasticache'
+require_relative 'dalli/elasticache'


### PR DESCRIPTION
Version 1.0.0 introduced an error loading the gem:

```
~/.asdf/installs/ruby/2.6.9/lib/ruby/gems/2.6.0/gems/bootsnap-1.10.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:15:in `require': cannot load such file -- elasticache (LoadError)
```

This is caused by an incorrect relative path to the `elasticache` file, which is located under the `dalli` directory.

The changes in this PR resolve the issue.