### PR TITLE
Fix flaky node hash spec and add TLS/refresh docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,57 @@ elasticache.refresh
 elasticache.refresh.client
 ```
 
+### TLS
+
+Pass an `OpenSSL::SSL::SSLContext` via `ssl_context:` to enable TLS for the auto-discovery connection. This uses the same interface as Dalli's own TLS support.
+
+```ruby
+ssl_context = OpenSSL::SSL::SSLContext.new
+ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+elasticache = Dalli::ElastiCache.new(
+  "my-cluster.abc123.cfg.use1.cache.amazonaws.com:11211",
+  { expires_in: 1.day },
+  ssl_context: ssl_context
+)
+```
+
+Note that `ssl_context:` controls TLS for the auto-discovery endpoint only. To also encrypt traffic to the cache nodes themselves, pass `ssl_context:` in the Dalli options as well:
+
+```ruby
+elasticache = Dalli::ElastiCache.new(endpoint, { ssl_context: ssl_context }, ssl_context: ssl_context)
+```
+
+### Refreshing the Node List
+
+The node list is fetched once and cached. Call `#refresh` to re-query the endpoint, which creates a new `Dalli::Client` with the current node list.
+
+Two common patterns for keeping the node list up to date:
+
+**On failure** — rescue `Dalli::RingError` (raised when no nodes are reachable) and refresh before retrying:
+
+```ruby
+begin
+  cache.get("key")
+rescue Dalli::RingError
+  elasticache.refresh
+  retry
+end
+```
+
+**On a schedule** — refresh periodically in a background thread or job. AWS does not publish exact timing for node replacement, but the process typically takes a few minutes, so refreshing every 60 seconds is a reasonable default:
+
+```ruby
+Thread.new do
+  loop do
+    sleep 60
+    elasticache.refresh
+  end
+end
+```
+
+A combination of both approaches is reasonable for production use.
+
 License
 -------
 

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -6,10 +6,10 @@ describe 'Dalli::Elasticache::AutoDiscovery::Node' do
   context 'when comparing with equals' do
     let(:host1) { Faker::Internet.domain_name(subdomain: true) }
     let(:ip1) { Faker::Internet.public_ip_v4_address }
-    let(:port1) { rand(1024..16_023) }
-    let(:host2) { Faker::Internet.domain_name(subdomain: true) }
-    let(:ip2) { Faker::Internet.public_ip_v4_address }
-    let(:port2) { rand(1024..16_023) }
+    let(:port1) { rand(1024..16_022) }
+    let(:host2) { "other.#{host1}" }
+    let(:ip2) { ip1 == '1.2.3.4' ? '1.2.3.5' : '1.2.3.4' }
+    let(:port2) { port1 + 1 }
 
     let(:node1a) { Dalli::Elasticache::AutoDiscovery::Node.new(host1, ip1, port1) }
     let(:node1b) { Dalli::Elasticache::AutoDiscovery::Node.new(host1, ip1, port1) }
@@ -36,10 +36,10 @@ describe 'Dalli::Elasticache::AutoDiscovery::Node' do
   context 'when used as a hash key' do
     let(:host1) { Faker::Internet.domain_name(subdomain: true) }
     let(:ip1) { Faker::Internet.public_ip_v4_address }
-    let(:port1) { rand(1024..16_023) }
-    let(:host2) { Faker::Internet.domain_name(subdomain: true) }
-    let(:ip2) { Faker::Internet.public_ip_v4_address }
-    let(:port2) { rand(1024..16_023) }
+    let(:port1) { rand(1024..16_022) }
+    let(:host2) { "other.#{host1}" }
+    let(:ip2) { ip1 == '1.2.3.4' ? '1.2.3.5' : '1.2.3.4' }
+    let(:port2) { port1 + 1 }
 
     let(:node1a) { Dalli::Elasticache::AutoDiscovery::Node.new(host1, ip1, port1) }
     let(:node1b) { Dalli::Elasticache::AutoDiscovery::Node.new(host1, ip1, port1) }


### PR DESCRIPTION
## Summary

- **Fix flaky test**: `node_spec` used independent `rand` calls for `port1` and `port2` (and `host`/`ip` equivalents), so they could occasionally produce the same value, making `node_with_different_port` accidentally identical to `node1a`. All "different" values are now deterministically distinct (`port1 + 1`, prefixed host, fixed-fallback IP). This was surfaced by the Ruby 3.4 CI run after merging #59.
- **README**: Add TLS usage example (from #59) and refresh frequency guidance (promised when closing #30).

## Test plan

- [x] All 42 examples pass
- [x] No RuboCop offenses
- [x] Node hash spec is now deterministic — the "different" variants are guaranteed to differ from the originals

🤖 Generated with [Claude Code](https://claude.com/claude-code)